### PR TITLE
feat(ci): publish snapshot-manifest.json with snapshot-latest release

### DIFF
--- a/.github/workflows/update-smt.yml
+++ b/.github/workflows/update-smt.yml
@@ -60,13 +60,22 @@ jobs:
       - name: Check if release needs update
         id: release-check
         run: |
-          # Upload if CRL changed OR if new asset types are missing from the release
+          # Upload if CRL changed OR if any required asset is missing from the release.
           if [ "${{ steps.build.outputs.changed }}" = "true" ]; then
             echo "needs_upload=true" >> "$GITHUB_OUTPUT"
-          elif ! gh release view snapshot-latest --json assets --jq '.assets[].name' 2>/dev/null | grep -q 'smt.wasm'; then
-            echo "needs_upload=true" >> "$GITHUB_OUTPUT"
           else
-            echo "needs_upload=false" >> "$GITHUB_OUTPUT"
+            published=$(gh release view snapshot-latest --json assets --jq '.assets[].name' 2>/dev/null || true)
+            missing=0
+            for required in smt.wasm snapshot-manifest.json; do
+              if ! grep -qx "$required" <<<"$published"; then
+                missing=1; break
+              fi
+            done
+            if [ "$missing" -eq 1 ]; then
+              echo "needs_upload=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "needs_upload=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -113,6 +122,33 @@ jobs:
             cp "$WASM_JS" wasm/wasm_exec.js
             assets="$assets wasm/wasm_exec.js"
           fi
+          # SHA-256 (decompressed for *.gz, raw otherwise) of every file the
+          # web prover hashes against. Consumed by hydrateManifest() in
+          # zkmopro/zkID's web app for fail-closed cache freshness.
+          MANIFEST=wasm/snapshot-manifest.json
+          sha_raw() { sha256sum "$1" | awk '{print $1}'; }
+          sha_decompressed_gz() { gunzip -c "$1" | sha256sum | awk '{print $1}'; }
+          {
+            echo '{'
+            echo '  "assets": {'
+            first=1
+            emit() {
+              local published="$1" sha="$2"
+              if [ "$first" -eq 1 ]; then first=0; else printf ',\n'; fi
+              printf '    "%s": { "sha256_decompressed": "%s" }' "$published" "$sha"
+            }
+            for gen in g2 g3; do
+              bin="data/${gen}/${gen}-tree-snapshot.bin.gz"
+              [ -f "$bin" ] && emit "${gen}-tree-snapshot.bin.gz" "$(sha_decompressed_gz "$bin")"
+            done
+            [ -f wasm/smt.wasm ] && emit "smt.wasm" "$(sha_raw wasm/smt.wasm)"
+            [ -f wasm/wasm_exec.js ] && emit "wasm_exec.js" "$(sha_raw wasm/wasm_exec.js)"
+            printf '\n'
+            echo '  }'
+            echo '}'
+          } > "$MANIFEST"
+          cat "$MANIFEST"
+          assets="$assets $MANIFEST"
           if [ -n "$assets" ]; then
             gh release create snapshot-latest \
               --title "SMT Snapshot" \


### PR DESCRIPTION
## Summary

- Add a step to the snapshot-latest publish workflow that generates \`snapshot-manifest.json\` (SHA-256 of decompressed bytes per asset) and uploads it alongside the existing \`*.bin.gz\` snapshots, \`smt.wasm\`, and \`wasm_exec.js\`.
- Extend the upload-needed check so the next scheduled run picks up an existing \`snapshot-latest\` that predates this change and is missing \`snapshot-manifest.json\` (no manual force-upload required).

## Why

[zkmopro/zkID#57](https://github.com/zkmopro/zkID/pull/57) rewires the in-browser prover so cache freshness is gated by an authoritative manifest published next to the assets. The web app fetches both \`/keys/manifest.json\` (zkID's own keys release) and \`/smt-snapshot/snapshot-manifest.json\` (this repo's release) on every warmup, and refuses to use a cached PK / witness wasm / SMT snapshot whose hash doesn't match what the manifest claims.

zkID's CI already publishes \`/keys/manifest.json\`. This PR closes the symmetric gap on the SMT side. After it lands, the next scheduled \`update-smt.yml\` run will re-upload \`snapshot-latest\` with \`snapshot-manifest.json\` included, and zkID's web prover will start passing fail-closed validation against this repo's release.

## Generated shape

```json
{
  "assets": {
    "g2-tree-snapshot.bin.gz": { "sha256_decompressed": "<hex>" },
    "g3-tree-snapshot.bin.gz": { "sha256_decompressed": "<hex>" },
    "smt.wasm":                { "sha256_decompressed": "<hex>" },
    "wasm_exec.js":            { "sha256_decompressed": "<hex>" }
  }
}
```

For \`*.bin.gz\` we hash the gunzipped bytes (matching the zkID convention); for \`smt.wasm\` and \`wasm_exec.js\` (served raw, not gzip-encoded), we hash the raw bytes.

## Test plan

- [x] Trigger the workflow manually (\`workflow_dispatch\`) and confirm \`snapshot-manifest.json\` appears in the \`snapshot-latest\` release alongside the other assets.
- [x] \`curl -s https://github.com/moven0831/moica-revocation-smt/releases/download/snapshot-latest/snapshot-manifest.json | jq .\` returns four entries with valid 64-char hex \`sha256_decompressed\` values.
- [x] Spot-check one entry: \`curl -sL .../g2-tree-snapshot.bin.gz | gunzip | shasum -a 256\` matches the manifest's \`g2-tree-snapshot.bin.gz\` hash.
- [x] zkmopro/zkID web prover loads cleanly against the new release (Setup screen reaches all-green, Continue enables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)