### PR TITLE
ci: add force_post_root input to update-smt workflow

### DIFF
--- a/.github/workflows/update-smt.yml
+++ b/.github/workflows/update-smt.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "0 4,16 * * *"
   workflow_dispatch:
+    inputs:
+      force_post_root:
+        description: "Post roots on-chain even if CRL data did not change"
+        type: boolean
+        default: false
 
 jobs:
   update:
@@ -123,7 +128,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Post root on-chain
-        if: steps.build.outputs.changed == 'true'
+        if: steps.build.outputs.changed == 'true' || inputs.force_post_root == true
         run: ./bin/smtbuild --post-root
         env:
           DATA_DIR: ./data


### PR DESCRIPTION
## Summary
- Add `force_post_root` boolean input to `update-smt.yml`'s `workflow_dispatch` trigger.
- Widen the `Post root on-chain` step gate to `steps.build.outputs.changed == 'true' || inputs.force_post_root == true` so a manual run can recover a stale on-chain root when the CRL itself hasn't changed.
- Other `changed`-gated steps (commit, release upload) untouched — scheduled runs behave identically.

## Why
If a previous run committed new CRL data but the on-chain `setRoot` failed (RPC outage, secret rotation, gas issue, etc.), the chain stays stale until MOICA publishes a new CRL because `changed=false` skips the post-root step. This input provides a safe manual override.

Safety: `SMTRootStorage.setRoot` enforces monotonic `crlNumber`, and `smtbuild --post-root` already swallows the `stale CRL` revert (`server/cmd/smtbuild/main.go:308`), so a redundant force-post against an already-current chain is a logged no-op.

## Test plan
- [ ] After merge, run `gh workflow run update-smt.yml -f force_post_root=true` and confirm `Post root on-chain` executes.
- [ ] Confirm `Commit data` and `Upload snapshot` are still skipped when `changed=false`.
- [ ] Confirm next scheduled cron run behaves identically to before (post-root only when CRL actually changed).
- [ ] Read `SMTRootStorage` for `IssuerG2`/`IssuerG3` and verify `crlNumber` matches `data/{g2,g3}/root.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)