### PR TITLE
Migrate on-chain root storage to Ethereum Mainnet

### DIFF
--- a/.github/workflows/update-smt.yml
+++ b/.github/workflows/update-smt.yml
@@ -135,3 +135,6 @@ jobs:
           RPC_URL: ${{ secrets.RPC_URL }}
           RELAYER_PRIVATE_KEY: ${{ secrets.RELAYER_PRIVATE_KEY }}
           CONTRACT_ADDRESS: ${{ secrets.CONTRACT_ADDRESS }}
+          # Mainnet gas guardrails. Defaults (100 gwei / 180s) apply if unset.
+          RELAYER_MAX_FEE_GWEI: ${{ vars.RELAYER_MAX_FEE_GWEI }}
+          RELAYER_TX_TIMEOUT_SEC: ${{ vars.RELAYER_TX_TIMEOUT_SEC }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Simple root registry: `setRoot(bytes32 issuerId, uint256 newRoot, uint256 crlNum
 ## CI/CD
 
 - **ci.yml** — On push/PR: Go unit tests + build, Hardhat contract tests, E2E integration tests (downloads real G2 snapshot)
-- **update-smt.yml** — Cron (04:00 & 16:00 UTC): smtbuild → commit snapshots → upload to `snapshot-latest` release → `smtbuild --post-root` posts roots on-chain (Arbitrum Sepolia)
+- **update-smt.yml** — Cron (04:00 & 16:00 UTC): smtbuild → commit snapshots → upload to `snapshot-latest` release → `smtbuild --post-root` posts roots on-chain (Ethereum Mainnet). The relayer enforces a `RELAYER_MAX_FEE_GWEI` gas ceiling and does same-nonce fee-bumped resends on confirmation timeout (`RELAYER_TX_TIMEOUT_SEC`)
 
 ## Data Scale
 

--- a/README.md
+++ b/README.md
@@ -120,9 +120,14 @@ Service `RevocationProofService` on port 50051 with `GetProof` and `GetStatus` R
 
 **SMTRootStorage.sol** — on-chain registry for SMT roots.
 
-**Deployed on Arbitrum Sepolia:** [`0xc461326eb6e46F10A276B0F14BFFf8b256A43FFA`](https://sepolia.arbiscan.io/address/0xc461326eb6e46F10A276B0F14BFFf8b256A43FFA)
+**Deployed contract:**
 
-The contract stores SMT Merkle roots on-chain so anyone can verify certificate revocation status against a trusted root. A CI relayer updates roots twice daily after rebuilding from MOICA CRL data. Each root is tied to a monotonically increasing CRL number to prevent stale updates. Anyone can call `getRoot(issuerId)` to read the latest root and verify proofs off-chain.
+| Network | Address |
+|---------|---------|
+| Ethereum Mainnet (production) | `0x…` — _set after deploy; link to [etherscan.io](https://etherscan.io)_ |
+| Arbitrum Sepolia (legacy testnet) | [`0xc461326eb6e46F10A276B0F14BFFf8b256A43FFA`](https://sepolia.arbiscan.io/address/0xc461326eb6e46F10A276B0F14BFFf8b256A43FFA) |
+
+The contract stores SMT Merkle roots on Ethereum Mainnet so anyone can verify certificate revocation status against a trusted root. A CI relayer updates roots after rebuilding from MOICA CRL data (cron runs twice daily; a transaction is sent only when the CRL actually changes). Each root is tied to a monotonically increasing CRL number to prevent stale updates. Anyone can call `getRoot(issuerId)` to read the latest root and verify proofs off-chain.
 
 | Function | Description |
 |----------|-------------|
@@ -131,20 +136,21 @@ The contract stores SMT Merkle roots on-chain so anyone can verify certificate r
 
 Issuer IDs: `keccak256("MOICA-G2")`, `keccak256("MOICA-G3")`
 
-Deploy to Arbitrum Sepolia:
+Deploy to Ethereum Mainnet (rehearse on the `sepolia` L1 testnet first):
 
-1. Generate relayer keypair: `cast wallet new`
-2. Fund relayer address with Arbitrum Sepolia ETH
-3. Deploy:
+1. Generate a fresh, dedicated relayer keypair: `cast wallet new`
+2. Fund the relayer address with mainnet ETH (covers gas for ~2 `setRoot` tx per CRL change; keep a buffer for gas spikes)
+3. Deploy with the optimizer-enabled `production` build profile:
 ```bash
 cd onchain-contract
 nvm use 22
 pnpm install
 npx hardhat ignition deploy ignition/modules/SMTRootStorage.ts \
-  --network arbitrumSepolia \
+  --network mainnet --build-profile production \
   --parameters '{"SMTRootStorageModule": {"relayer": "0x<RELAYER_ADDRESS>"}}'
 ```
-4. Set GitHub Actions secrets: `RPC_URL`, `RELAYER_PRIVATE_KEY` (hex, no `0x`), `CONTRACT_ADDRESS`
+4. Verify the source on Etherscan for transparency
+5. Set GitHub Actions secrets (`RPC_URL` → mainnet RPC, `RELAYER_PRIVATE_KEY` hex no `0x`, `CONTRACT_ADDRESS` → deployed address) and optionally the variables `RELAYER_MAX_FEE_GWEI` / `RELAYER_TX_TIMEOUT_SEC` to tune the gas ceiling and confirmation timeout
 
 Post roots on-chain manually (reads `root.json` files, skips gracefully if env vars are unset):
 ```bash
@@ -167,6 +173,8 @@ See [onchain-contract/README.md](onchain-contract/README.md) for detailed setup 
 | `RPC_URL` | — | Ethereum JSON-RPC URL |
 | `RELAYER_PRIVATE_KEY` | — | Hex private key for chain relayer |
 | `CONTRACT_ADDRESS` | — | SMTRootStorage contract address |
+| `RELAYER_MAX_FEE_GWEI` | 100 | Max gas fee per gas the relayer will pay; aborts posting above this ceiling |
+| `RELAYER_TX_TIMEOUT_SEC` | 180 | Per-tx confirmation timeout before a same-nonce fee-bumped resend |
 | `GITHUB_REPO` | `moven0831/moica-revocation-smt` | GitHub repo for snapshot releases |
 
 ## Client-Side WASM
@@ -271,7 +279,7 @@ The same binary snapshot and proof format work across platforms:
 1. Build server binary + WASM module
 2. Fetch CRL, build SMT, export JSON + binary snapshots (skipped if merkle root is unchanged)
 3. Upload snapshots, WASM module, and `wasm_exec.js` to GitHub Release (`snapshot-latest`)
-4. Post root on-chain via `smtbuild --post-root` (Arbitrum Sepolia)
+4. Post root on-chain via `smtbuild --post-root` (Ethereum Mainnet), bounded by the `RELAYER_MAX_FEE_GWEI` gas ceiling
 
 Required secrets: `RPC_URL`, `RELAYER_PRIVATE_KEY`, `CONTRACT_ADDRESS` (on-chain posting skips gracefully if unset)
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Service `RevocationProofService` on port 50051 with `GetProof` and `GetStatus` R
 
 | Network | Address |
 |---------|---------|
-| Ethereum Mainnet (production) | `0x…` — _set after deploy; link to [etherscan.io](https://etherscan.io)_ |
+| Ethereum Mainnet (production) | [`0xf3aAAe2D017dcC9cA901aDC9Da419f1C70362ab1`](https://etherscan.io/address/0xf3aAAe2D017dcC9cA901aDC9Da419f1C70362ab1) |
 | Arbitrum Sepolia (legacy testnet) | [`0xc461326eb6e46F10A276B0F14BFFf8b256A43FFA`](https://sepolia.arbiscan.io/address/0xc461326eb6e46F10A276B0F14BFFf8b256A43FFA) |
 
 The contract stores SMT Merkle roots on Ethereum Mainnet so anyone can verify certificate revocation status against a trusted root. A CI relayer updates roots after rebuilding from MOICA CRL data (cron runs twice daily; a transaction is sent only when the CRL actually changes). Each root is tied to a monotonically increasing CRL number to prevent stale updates. Anyone can call `getRoot(issuerId)` to read the latest root and verify proofs off-chain.

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Web or mobile clients can use the published release artifacts to load an SMT and
 2. **Fetch snapshot** — download `g2-tree-snapshot.bin.gz` and decompress (browser: `DecompressionStream`, native: `gzip` library)
 3. **Build tree** — parse 52-byte binary header → `smtInitTree(nodeCount, depth)` → stream nodes via `smtAddNodeChunk(chunk)` in batches of ~10,000 → `smtFinalize(rootHex, leafCount)`
 4. **Generate proof** — `smtCreateProof(serialNumberHex)` → parse JSON → convert hex to decimal strings → pad siblings to depth 128
-5. **Feed to circuit** — proof fields (`smtRoot`, `smtSiblings[128]`, `smtOldKey`, `smtOldValue`, `smtIsOld0`) become inputs for `SMTNonMembershipVerifier(128)` in the [zkID](https://github.com/zkmopro/zkID) circom circuit
+5. **Feed to circuit** — proof fields (`smtRoot`, `smtSiblings[128]`, `smtOldKey`, `smtOldValue`, `smtIsOld0`) become inputs for `SMTNonMembershipVerifier(128)` in the [zkID](https://github.com/privacy-ethereum/zkID/tree/RSA-X.509-Cert) circom circuit
 
 ### Release Assets
 
@@ -306,4 +306,4 @@ Wire-compatible with `@zk-kit/smt` v1.0.2 (`bigNumbers` mode):
 - [MOICA](https://moica.nat.gov.tw/) — Taiwan citizen digital certificate
 - [Poseidon Hash](https://www.poseidon-hash.info/) — ZK-friendly hash function
 - [Hadeshash spec](https://eprint.iacr.org/2019/458.pdf) — Round number parameters
-- [zkID](https://github.com/zkmopro/zkID) — ZK identity verification project
+- [zkID](https://github.com/privacy-ethereum/zkID/tree/RSA-X.509-Cert) — ZK identity verification project

--- a/onchain-contract/README.md
+++ b/onchain-contract/README.md
@@ -6,9 +6,10 @@ On-chain registry for Sparse Merkle Tree roots from MOICA Certificate Revocation
 
 | Network | Address |
 |---------|---------|
-| Arbitrum Sepolia | [`0xc461326eb6e46F10A276B0F14BFFf8b256A43FFA`](https://sepolia.arbiscan.io/address/0xc461326eb6e46F10A276B0F14BFFf8b256A43FFA) |
+| Ethereum Mainnet (production) | `0x…` — _set after deploy; link to [etherscan.io](https://etherscan.io)_ |
+| Arbitrum Sepolia (legacy testnet) | [`0xc461326eb6e46F10A276B0F14BFFf8b256A43FFA`](https://sepolia.arbiscan.io/address/0xc461326eb6e46F10A276B0F14BFFf8b256A43FFA) |
 
-The CRL pipeline (fetch → parse → build SMT) produces a Merkle root per issuer, which the CI relayer posts on-chain via `setRoot()`. The contract enforces monotonic CRL numbers to prevent stale updates. Anyone can read the latest root with `getRoot(issuerId)` and verify membership/non-membership proofs off-chain.
+The CRL pipeline (fetch → parse → build SMT) produces a Merkle root per issuer, which the CI relayer posts on Ethereum Mainnet via `setRoot()`. The contract enforces monotonic CRL numbers to prevent stale updates. Anyone can read the latest root with `getRoot(issuerId)` and verify membership/non-membership proofs off-chain.
 
 ## Contract
 
@@ -73,22 +74,25 @@ Save the private key (without `0x` prefix) and note the address.
 
 ### 2. Fund the relayer
 
-Send Arbitrum Sepolia ETH to the relayer address. You can get testnet ETH from an [Arbitrum Sepolia faucet](https://www.alchemy.com/faucets/arbitrum-sepolia).
+Send mainnet ETH to the relayer address — enough to cover gas for ~2 `setRoot` transactions per CRL change, with a buffer for gas spikes. Use a fresh, dedicated key (do not reuse a testnet key).
 
 ### 3. Deploy contract
 
-Local/default network:
+Rehearse on the Ethereum Sepolia L1 testnet first (requires `SEPOLIA_RPC_URL` and `SEPOLIA_PRIVATE_KEY`) — it exercises real EIP-1559 and the relayer fee ceiling, unlike the Arbitrum testnet:
 ```bash
 npx hardhat ignition deploy ignition/modules/SMTRootStorage.ts \
+  --network sepolia --build-profile production \
   --parameters '{"SMTRootStorageModule": {"relayer": "0x<RELAYER_ADDRESS>"}}'
 ```
 
-Arbitrum Sepolia (requires `ARB_SEPOLIA_RPC_URL` and `ARB_SEPOLIA_PRIVATE_KEY` env vars):
+Ethereum Mainnet (requires `MAINNET_RPC_URL` and `MAINNET_PRIVATE_KEY`), deployed with the optimizer-enabled `production` profile:
 ```bash
 npx hardhat ignition deploy ignition/modules/SMTRootStorage.ts \
-  --network arbitrumSepolia \
+  --network mainnet --build-profile production \
   --parameters '{"SMTRootStorageModule": {"relayer": "0x<RELAYER_ADDRESS>"}}'
 ```
+
+Then verify the contract source on Etherscan for transparency.
 
 ### 4. Configure GitHub Actions secrets
 
@@ -96,9 +100,16 @@ Set these repository secrets for automated on-chain posting:
 
 | Secret | Value |
 |--------|-------|
-| `RPC_URL` | Arbitrum Sepolia RPC endpoint (e.g. from Alchemy/Infura) |
+| `RPC_URL` | Ethereum Mainnet RPC endpoint (e.g. from Alchemy/Infura) |
 | `RELAYER_PRIVATE_KEY` | Hex private key without `0x` prefix |
 | `CONTRACT_ADDRESS` | Deployed `SMTRootStorage` contract address |
+
+Optionally set these repository **variables** to tune mainnet gas behavior (defaults apply if unset):
+
+| Variable | Default | Value |
+|----------|---------|-------|
+| `RELAYER_MAX_FEE_GWEI` | 100 | Max gas fee per gas the relayer will pay; it skips posting above this ceiling |
+| `RELAYER_TX_TIMEOUT_SEC` | 180 | Per-tx confirmation timeout before a same-nonce fee-bumped resend |
 
 ## CI/CD Integration
 

--- a/onchain-contract/README.md
+++ b/onchain-contract/README.md
@@ -6,7 +6,7 @@ On-chain registry for Sparse Merkle Tree roots from MOICA Certificate Revocation
 
 | Network | Address |
 |---------|---------|
-| Ethereum Mainnet (production) | `0x…` — _set after deploy; link to [etherscan.io](https://etherscan.io)_ |
+| Ethereum Mainnet (production) | [`0xf3aAAe2D017dcC9cA901aDC9Da419f1C70362ab1`](https://etherscan.io/address/0xf3aAAe2D017dcC9cA901aDC9Da419f1C70362ab1) |
 | Arbitrum Sepolia (legacy testnet) | [`0xc461326eb6e46F10A276B0F14BFFf8b256A43FFA`](https://sepolia.arbiscan.io/address/0xc461326eb6e46F10A276B0F14BFFf8b256A43FFA) |
 
 The CRL pipeline (fetch → parse → build SMT) produces a Merkle root per issuer, which the CI relayer posts on Ethereum Mainnet via `setRoot()`. The contract enforces monotonic CRL numbers to prevent stale updates. Anyone can read the latest root with `getRoot(issuerId)` and verify membership/non-membership proofs off-chain.

--- a/onchain-contract/hardhat.config.ts
+++ b/onchain-contract/hardhat.config.ts
@@ -28,6 +28,12 @@ export default defineConfig({
       type: "edr-simulated",
       chainType: "op",
     },
+    mainnet: {
+      type: "http",
+      chainType: "l1",
+      url: configVariable("MAINNET_RPC_URL"),
+      accounts: [configVariable("MAINNET_PRIVATE_KEY")],
+    },
     sepolia: {
       type: "http",
       chainType: "l1",

--- a/server/cmd/smtbuild/main.go
+++ b/server/cmd/smtbuild/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -252,7 +253,10 @@ func postRootOnChain(cfg *config.Config) {
 	}
 	defer client.Close()
 
-	relayer, err := chain.NewRelayer(client, cfg.RelayerPrivateKey, cfg.ContractAddress)
+	relayer, err := chain.NewRelayer(client, cfg.RelayerPrivateKey, cfg.ContractAddress,
+		chain.WithMaxFeeGwei(cfg.RelayerMaxFeeGwei),
+		chain.WithConfirmTimeout(time.Duration(cfg.RelayerTxTimeoutSec)*time.Second),
+	)
 	if err != nil {
 		log.Fatalf("Failed to create relayer: %v", err)
 	}
@@ -274,7 +278,12 @@ func postRootOnChain(cfg *config.Config) {
 		{ID: "g3", IssuerID: chain.IssuerG3},
 	}
 
-	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Minute)
+	// Allow enough wall-clock for fee-bumped replacements across every issuer.
+	overall := time.Duration(len(entries))*relayer.MaxPostDuration() + time.Minute
+	if overall < 5*time.Minute {
+		overall = 5 * time.Minute
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), overall)
 	defer cancel()
 	for _, iss := range entries {
 		rootPath := filepath.Join(cfg.DataDir, iss.ID, "root.json")
@@ -307,6 +316,10 @@ func postRootOnChain(cfg *config.Config) {
 		if err != nil {
 			if strings.Contains(err.Error(), "stale CRL") {
 				log.Printf("[%s] Already posted (stale CRL), skipping", iss.ID)
+				continue
+			}
+			if errors.Is(err, chain.ErrFeeCeilingExceeded) {
+				log.Printf("[%s] Skipping: %v (raise RELAYER_MAX_FEE_GWEI or retry when gas drops)", iss.ID, err)
 				continue
 			}
 			log.Printf("[%s] Failed to post root: %v", iss.ID, err)

--- a/server/internal/chain/relayer.go
+++ b/server/internal/chain/relayer.go
@@ -3,13 +3,16 @@ package chain
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/moven0831/moica-revocation-smt/server/internal/chain/contract"
 )
 
@@ -18,6 +21,15 @@ var (
 	IssuerG2 = crypto.Keccak256Hash([]byte("MOICA-G2"))
 	IssuerG3 = crypto.Keccak256Hash([]byte("MOICA-G3"))
 )
+
+// maxReplacementAttempts is the default number of fee-bumped resends the relayer
+// tries when a transaction is not confirmed within the confirm timeout.
+const maxReplacementAttempts = 3
+
+// ErrFeeCeilingExceeded is returned when the live gas fee (or a required fee bump)
+// would exceed the configured ceiling. Callers can detect it with errors.Is and
+// skip posting rather than overpay during a gas spike.
+var ErrFeeCeilingExceeded = errors.New("gas fee exceeds configured ceiling")
 
 // EthBackend combines the interfaces needed for contract interaction and transaction mining.
 type EthBackend interface {
@@ -32,10 +44,42 @@ type Relayer struct {
 	privateKey      *ecdsa.PrivateKey
 	contractAddress common.Address
 	chainID         *big.Int
+
+	// maxFeeWei caps the EIP-1559 fee per gas. nil means no ceiling.
+	maxFeeWei *big.Int
+	// confirmTimeout bounds how long to wait for each send before attempting a
+	// fee-bumped replacement. 0 means wait on the caller's context with no replacement.
+	confirmTimeout time.Duration
+	// maxReplacements is the number of fee-bumped resends attempted on timeout.
+	maxReplacements int
+}
+
+// RelayerOption configures optional relayer behavior.
+type RelayerOption func(*Relayer)
+
+// WithMaxFeeGwei sets the maximum gas fee per gas the relayer will pay, in gwei.
+// A value <= 0 leaves the ceiling disabled (no cap).
+func WithMaxFeeGwei(gwei int) RelayerOption {
+	return func(r *Relayer) {
+		if gwei > 0 {
+			r.maxFeeWei = new(big.Int).Mul(big.NewInt(int64(gwei)), big.NewInt(params.GWei))
+		}
+	}
+}
+
+// WithConfirmTimeout sets the per-transaction confirmation timeout. On timeout the
+// relayer resends at the same nonce with a bumped fee. A value <= 0 disables
+// replacement and waits on the caller's context.
+func WithConfirmTimeout(d time.Duration) RelayerOption {
+	return func(r *Relayer) {
+		if d > 0 {
+			r.confirmTimeout = d
+		}
+	}
 }
 
 // NewRelayer creates a relayer from a hex private key and contract address.
-func NewRelayer(client *Client, privateKeyHex string, contractAddr string) (*Relayer, error) {
+func NewRelayer(client *Client, privateKeyHex string, contractAddr string, opts ...RelayerOption) (*Relayer, error) {
 	pk, err := crypto.HexToECDSA(privateKeyHex)
 	if err != nil {
 		return nil, fmt.Errorf("parse private key: %w", err)
@@ -46,13 +90,18 @@ func NewRelayer(client *Client, privateKeyHex string, contractAddr string) (*Rel
 		return nil, fmt.Errorf("get chain ID: %w", err)
 	}
 
-	return &Relayer{
+	r := &Relayer{
 		client:          client,
 		backend:         client.Eth(),
 		privateKey:      pk,
 		contractAddress: common.HexToAddress(contractAddr),
 		chainID:         chainID,
-	}, nil
+		maxReplacements: maxReplacementAttempts,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r, nil
 }
 
 // TransactOpts returns a signed transactor for the relayer.
@@ -95,7 +144,15 @@ func (r *Relayer) VerifyContract(ctx context.Context) error {
 	return nil
 }
 
-// PostRoot sends a setRoot transaction to the SMTRootStorage contract and waits for confirmation.
+// MaxPostDuration is the worst-case time a single PostRoot may take, given the
+// confirm timeout and the fee-bumped resends. Callers use it to size deadlines.
+func (r *Relayer) MaxPostDuration() time.Duration {
+	return time.Duration(r.maxReplacements+1) * r.confirmTimeout
+}
+
+// PostRoot sends a setRoot transaction to the SMTRootStorage contract and waits for
+// confirmation, bounding the fee by the configured ceiling and resending at the same
+// nonce with a bumped fee if it is not mined within the confirm timeout.
 func (r *Relayer) PostRoot(ctx context.Context, issuerID [32]byte, root *big.Int, crlNumber *big.Int) (*types.Transaction, error) {
 	instance, err := contract.NewSMTRootStorage(r.contractAddress, r.backend)
 	if err != nil {
@@ -107,18 +164,122 @@ func (r *Relayer) PostRoot(ctx context.Context, issuerID [32]byte, root *big.Int
 		return nil, fmt.Errorf("transact opts: %w", err)
 	}
 
-	tx, err := instance.SetRoot(opts, issuerID, root, crlNumber)
+	if err := r.applyGasBounds(ctx, opts); err != nil {
+		return nil, err
+	}
+	return r.sendAndConfirm(ctx, opts, func(o *bind.TransactOpts) (*types.Transaction, error) {
+		return instance.SetRoot(o, issuerID, root, crlNumber)
+	})
+}
+
+// applyGasBounds sets EIP-1559 fees bounded by the configured ceiling and pins the
+// nonce. It returns ErrFeeCeilingExceeded when base fee + tip already exceeds the ceiling.
+func (r *Relayer) applyGasBounds(ctx context.Context, opts *bind.TransactOpts) error {
+	tip, err := r.backend.SuggestGasTipCap(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("setRoot: %w", err)
+		return fmt.Errorf("suggest gas tip: %w", err)
+	}
+	head, err := r.backend.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("fetch head: %w", err)
+	}
+	if head.BaseFee == nil {
+		return fmt.Errorf("chain has no base fee (pre-EIP-1559 not supported)")
 	}
 
-	receipt, err := bind.WaitMined(ctx, r.backend, tx)
-	if err != nil {
-		return tx, fmt.Errorf("wait mined: %w", err)
-	}
-	if receipt.Status == 0 {
-		return tx, fmt.Errorf("transaction reverted: %s", tx.Hash().Hex())
+	minFee := new(big.Int).Add(head.BaseFee, tip)
+	if r.maxFeeWei != nil && minFee.Cmp(r.maxFeeWei) > 0 {
+		return fmt.Errorf("%w: base fee + tip %s gwei > ceiling %s gwei",
+			ErrFeeCeilingExceeded, weiToGwei(minFee), weiToGwei(r.maxFeeWei))
 	}
 
-	return tx, nil
+	// 2*baseFee + tip leaves headroom for a few blocks of base-fee growth.
+	feeCap := new(big.Int).Add(new(big.Int).Lsh(head.BaseFee, 1), tip)
+	if r.maxFeeWei != nil && feeCap.Cmp(r.maxFeeWei) > 0 {
+		feeCap = new(big.Int).Set(r.maxFeeWei)
+	}
+	opts.GasTipCap = tip
+	opts.GasFeeCap = feeCap
+	return r.pinNonce(ctx, opts)
+}
+
+// pinNonce fixes the transaction nonce so that every resend in sendAndConfirm
+// reuses it, replacing the prior tx rather than queuing a new one behind it.
+func (r *Relayer) pinNonce(ctx context.Context, opts *bind.TransactOpts) error {
+	nonce, err := r.backend.PendingNonceAt(ctx, r.Address())
+	if err != nil {
+		return fmt.Errorf("fetch nonce: %w", err)
+	}
+	opts.Nonce = new(big.Int).SetUint64(nonce)
+	return nil
+}
+
+// sendAndConfirm sends the transaction and waits for confirmation, resending at the
+// same nonce with a bumped fee if it is not mined within confirmTimeout.
+func (r *Relayer) sendAndConfirm(ctx context.Context, opts *bind.TransactOpts, send func(*bind.TransactOpts) (*types.Transaction, error)) (*types.Transaction, error) {
+	for attempt := 0; ; attempt++ {
+		tx, err := send(opts)
+		if err != nil {
+			return nil, fmt.Errorf("setRoot: %w", err)
+		}
+
+		waitCtx := ctx
+		var cancel context.CancelFunc
+		if r.confirmTimeout > 0 {
+			waitCtx, cancel = context.WithTimeout(ctx, r.confirmTimeout)
+		}
+		receipt, err := bind.WaitMined(waitCtx, r.backend, tx)
+		if cancel != nil {
+			cancel()
+		}
+
+		if err == nil {
+			if receipt.Status == 0 {
+				return tx, fmt.Errorf("transaction reverted: %s", tx.Hash().Hex())
+			}
+			return tx, nil
+		}
+
+		// A per-attempt timeout (parent ctx still alive) is retryable; the parent
+		// ctx expiring or being canceled is terminal.
+		if ctx.Err() != nil {
+			return tx, fmt.Errorf("wait mined: %w", err)
+		}
+		if attempt >= r.maxReplacements {
+			return tx, fmt.Errorf("tx %s not confirmed after %d attempt(s) at nonce %v; still pending: %w",
+				tx.Hash().Hex(), attempt+1, opts.Nonce, err)
+		}
+		if bumpErr := r.bumpFees(opts); bumpErr != nil {
+			return tx, bumpErr
+		}
+	}
+}
+
+// bumpFees raises the transaction fee by ~13% (above the 10% replacement minimum),
+// staying within the ceiling. It returns ErrFeeCeilingExceeded when a legal bump
+// would exceed the ceiling, meaning the tx is stuck at the cap and we refuse to overpay.
+func (r *Relayer) bumpFees(opts *bind.TransactOpts) error {
+	// +13% (clears the node's 10% replacement threshold), with a 1-wei floor so
+	// even tiny fees strictly increase and integer truncation can't stall a resend.
+	bump := func(v *big.Int) *big.Int {
+		inc := new(big.Int).Div(new(big.Int).Mul(v, big.NewInt(13)), big.NewInt(100))
+		if inc.Sign() == 0 {
+			inc = big.NewInt(1)
+		}
+		return new(big.Int).Add(v, inc)
+	}
+
+	nextFeeCap := bump(opts.GasFeeCap)
+	if r.maxFeeWei != nil && nextFeeCap.Cmp(r.maxFeeWei) > 0 {
+		return fmt.Errorf("%w: cannot bump fee cap above %s gwei (tx stuck at ceiling)",
+			ErrFeeCeilingExceeded, weiToGwei(r.maxFeeWei))
+	}
+	opts.GasTipCap = bump(opts.GasTipCap)
+	opts.GasFeeCap = nextFeeCap
+	return nil
+}
+
+// weiToGwei formats a wei amount as a gwei string with two decimals, for log/error messages.
+func weiToGwei(wei *big.Int) string {
+	return new(big.Rat).SetFrac(wei, big.NewInt(params.GWei)).FloatString(2)
 }

--- a/server/internal/chain/relayer_test.go
+++ b/server/internal/chain/relayer_test.go
@@ -3,6 +3,7 @@ package chain
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"math/big"
 	"strings"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient/simulated"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/moven0831/moica-revocation-smt/server/internal/chain/contract"
 )
 
@@ -185,6 +187,97 @@ func TestPostRootStaleCRL(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "stale CRL") {
 		t.Errorf("expected 'stale CRL' in error, got: %v", err)
+	}
+}
+
+func TestPostRootFeeCeilingExceeded(t *testing.T) {
+	env := newTestEnv(t)
+
+	// A 1-wei ceiling is far below any realistic base fee + tip, so the relayer
+	// should refuse to send rather than overpay.
+	env.relayer.maxFeeWei = big.NewInt(1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := env.relayer.PostRoot(ctx, IssuerG2, big.NewInt(123), big.NewInt(100))
+	if err == nil {
+		t.Fatal("expected fee-ceiling error, got nil")
+	}
+	if !errors.Is(err, ErrFeeCeilingExceeded) {
+		t.Fatalf("expected ErrFeeCeilingExceeded, got: %v", err)
+	}
+
+	// Nothing should have been posted.
+	stored, err := env.contract.GetRoot(nil, IssuerG2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Sign() != 0 {
+		t.Errorf("expected no root stored, got %s", stored)
+	}
+}
+
+func TestPostRootWithFeeCeiling(t *testing.T) {
+	env := newTestEnv(t)
+
+	done := make(chan struct{})
+	defer close(done)
+	commitPeriodically(t, env.backend, done)
+
+	// Generous 1000-gwei ceiling — well above the simulated base fee, so the tx
+	// is sent with explicit dynamic fees bounded by the ceiling.
+	env.relayer.maxFeeWei = new(big.Int).Mul(big.NewInt(1000), big.NewInt(params.GWei))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tx, err := env.relayer.PostRoot(ctx, IssuerG2, big.NewInt(777), big.NewInt(100))
+	if err != nil {
+		t.Fatalf("PostRoot failed: %v", err)
+	}
+	if tx.Type() != types.DynamicFeeTxType {
+		t.Errorf("expected dynamic-fee tx, got type %d", tx.Type())
+	}
+	if tx.GasFeeCap() == nil || tx.GasFeeCap().Sign() == 0 {
+		t.Errorf("expected non-zero fee cap, got %v", tx.GasFeeCap())
+	}
+	if tx.GasFeeCap().Cmp(env.relayer.maxFeeWei) > 0 {
+		t.Errorf("fee cap %s exceeds ceiling %s", tx.GasFeeCap(), env.relayer.maxFeeWei)
+	}
+
+	stored, err := env.contract.GetRoot(nil, IssuerG2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Cmp(big.NewInt(777)) != 0 {
+		t.Errorf("stored root = %s, want 777", stored)
+	}
+}
+
+func TestPostRootResendOnTimeout(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Never commit, so the tx can't mine and every confirm attempt times out.
+	// The relayer should resend (fee-bumped, same nonce) maxReplacements times,
+	// then give up with a "not confirmed" error rather than hanging.
+	env.relayer.confirmTimeout = 80 * time.Millisecond
+	env.relayer.maxReplacements = 2
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := env.relayer.PostRoot(ctx, IssuerG2, big.NewInt(555), big.NewInt(100))
+	if err == nil {
+		t.Fatal("expected a not-confirmed error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not confirmed") {
+		t.Fatalf("expected 'not confirmed' error, got: %v", err)
+	}
+	// The caller's context is still alive — failure must come from exhausting
+	// replacements, not from the parent context expiring.
+	if ctx.Err() != nil {
+		t.Fatalf("parent context should still be alive, got: %v", ctx.Err())
 	}
 }
 

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -24,22 +24,31 @@ type Config struct {
 	RelayerPrivateKey string
 	// Contract address
 	ContractAddress string
+	// Maximum gas fee per gas the relayer will pay, in gwei. The relayer
+	// refuses to send a setRoot transaction when the live fee exceeds this
+	// ceiling (protects against gas-spike overpay on mainnet).
+	RelayerMaxFeeGwei int
+	// Per-transaction confirmation timeout in seconds. On timeout the relayer
+	// resends at the same nonce with a bumped fee to clear stuck/underpriced txs.
+	RelayerTxTimeoutSec int
 	// GitHub repo for snapshot downloads
 	GitHubRepo string
 }
 
 func Load() *Config {
 	return &Config{
-		Port:              getEnvInt("PORT", 3000),
-		GRPCPort:          getEnvInt("GRPC_PORT", 50051),
-		DataDir:           getEnv("DATA_DIR", "./data"),
-		CRLG2URL:          getEnv("CRL_G2_URL", "https://moica.nat.gov.tw/repository/MOICA/CRL2/complete.crl"),
-		CRLG3URL:          getEnv("CRL_G3_URL", "https://crl-moica.moi.gov.tw/crl/MOICA-G3-complete.crl"),
-		CRLPollInterval:   getEnvInt("CRL_POLL_INTERVAL", 21600), // 6 hours
-		RPCURL:            getEnv("RPC_URL", ""),
-		RelayerPrivateKey: getEnv("RELAYER_PRIVATE_KEY", ""),
-		ContractAddress:   getEnv("CONTRACT_ADDRESS", ""),
-		GitHubRepo:        getEnv("GITHUB_REPO", "moven0831/moica-revocation-smt"),
+		Port:                getEnvInt("PORT", 3000),
+		GRPCPort:            getEnvInt("GRPC_PORT", 50051),
+		DataDir:             getEnv("DATA_DIR", "./data"),
+		CRLG2URL:            getEnv("CRL_G2_URL", "https://moica.nat.gov.tw/repository/MOICA/CRL2/complete.crl"),
+		CRLG3URL:            getEnv("CRL_G3_URL", "https://crl-moica.moi.gov.tw/crl/MOICA-G3-complete.crl"),
+		CRLPollInterval:     getEnvInt("CRL_POLL_INTERVAL", 21600), // 6 hours
+		RPCURL:              getEnv("RPC_URL", ""),
+		RelayerPrivateKey:   getEnv("RELAYER_PRIVATE_KEY", ""),
+		ContractAddress:     getEnv("CONTRACT_ADDRESS", ""),
+		RelayerMaxFeeGwei:   getEnvInt("RELAYER_MAX_FEE_GWEI", 100),
+		RelayerTxTimeoutSec: getEnvInt("RELAYER_TX_TIMEOUT_SEC", 180),
+		GitHubRepo:          getEnv("GITHUB_REPO", "moven0831/moica-revocation-smt"),
 	}
 }
 


### PR DESCRIPTION
## Context

The `SMTRootStorage` contract currently lives on **Arbitrum Sepolia** (testnet). This migrates production root posting to **Ethereum L1 Mainnet** for maximum trust/decentralization, and hardens the relayer now that gas costs real ETH.

The contract Solidity is **unchanged** — the existing `SMTRootStorage` is simply redeployed. The Go relayer was already chain-agnostic (chain ID from RPC, no hardcoded addresses/gas), so the migration is config + deploy + gas hardening.

## Code changes

- **Hardhat** (`hardhat.config.ts`): add a `mainnet` network (`MAINNET_RPC_URL` / `MAINNET_PRIVATE_KEY`). Ignition module unchanged.
- **Relayer** (`internal/chain/relayer.go`):
  - Bound the EIP-1559 fee by a configurable gwei ceiling. If `base fee + tip` already exceeds the ceiling, abort with `ErrFeeCeilingExceeded` rather than overpay during a spike.
  - Pin the nonce and **resend at the same nonce with a fee bump** on confirmation timeout, up to a bounded number of attempts, so an underpriced tx can't wedge the run.
  - `MaxPostDuration()` lets the caller size its deadline without reaching into relayer internals.
- **Config** (`internal/config/config.go`): `RELAYER_MAX_FEE_GWEI` (default 100) and `RELAYER_TX_TIMEOUT_SEC` (default 180).
- **CLI** (`cmd/smtbuild`): wire the options in; log ceiling-skips distinctly.
- **CI** (`update-smt.yml`): pass the two gas-guardrail vars (empty → defaults).
- **Docs**: Ethereum Mainnet as production, Arbitrum Sepolia marked legacy; deploy steps updated (real ETH, `--build-profile production`, Etherscan verify, Sepolia L1 rehearsal).

## Operational steps (still required — need a funded key + repo admin)

1. Generate a fresh, dedicated mainnet relayer key and fund it with ETH.
2. Deploy: `npx hardhat ignition deploy … --network mainnet --build-profile production --parameters '{"SMTRootStorageModule":{"relayer":"0x…"}}'`. **Rehearse on `--network sepolia` first** (real EIP-1559 + fee ceiling).
3. Verify source on Etherscan; fill the `0x…` placeholders in the READMEs with the real address.
4. Update the `SMTRootStorageModule` secrets: `RPC_URL` → mainnet, `CONTRACT_ADDRESS` → new, `RELAYER_PRIVATE_KEY` → mainnet key; optionally set the `RELAYER_MAX_FEE_GWEI` / `RELAYER_TX_TIMEOUT_SEC` variables.
5. Smoke test: trigger `update-smt.yml` with `force_post_root: true`; confirm `RootUpdated` on Etherscan and `getRoot` matches `data/{g2,g3}/root.json`.

## Verification

`gofmt` clean · `go vet ./...` (incl. `-tags=integration`) clean · `make test` passes · `go test ./internal/chain/ -v` passes (9 tests incl. fee-ceiling, fee-cap-applied, and resend-on-timeout) · `npx hardhat test` passes (contract unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)